### PR TITLE
feat: use release-please to automate release versioning for microservices

### DIFF
--- a/.github/workflows/release-please-microservice.yml
+++ b/.github/workflows/release-please-microservice.yml
@@ -1,15 +1,10 @@
-name: Release Microservice
+name: Release Please - Microservice
 on:
   workflow_call:
-    inputs:
-      repository-language:
-        required: true
-        type: string
 
 jobs:
   create_runner:
     name: Create Runner
-    if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -28,28 +23,11 @@ jobs:
           docker_enabled: true
     outputs:
       runner_label: ${{ steps.create_runner.outputs.runner_label }}
-  get_version:
-    name: Get Application Version
-    runs-on: [self-hosted, "${{ needs.create_runner.outputs.runner_label }}"]
-    needs: create_runner
-    outputs:
-      app_version: ${{ steps.get_version.outputs.app_version }}
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      - name: Get Version (Python)
-        if: ${{ inputs.repository-language }} == 'python'
-        id: get_version
-        run: |
-          export "APP_VERSION=$(poetry version --short)"
-          echo "APP_VERSION=$APP_VERSION" >> "$GITHUB_OUTPUT"
   publish_artifacts:
     name: Publish Artifacts
     runs-on: [self-hosted, "${{ needs.create_runner.outputs.runner_label }}"]
     needs:
       - create_runner
-      - get_version
     steps:
       - name: Checkout
         id: checkout
@@ -72,7 +50,7 @@ jobs:
         env:
           REGISTRY: ${{ steps.ecr_login.outputs.registry }}
           REPOSITORY: ${{ github.event.repository.name }}
-          IMAGE_TAG: ${{ needs.get_version.outputs.app_version }}
+          IMAGE_TAG: $(jq -r '."."' .release-please-manifest.json)
           DOCKER_BUILDKIT: 1
         run: |
           docker build \
@@ -82,8 +60,8 @@ jobs:
           docker push $REGISTRY/$REPOSITORY:latest
       - name: Push Helm Chart to AWS ECR
         env:
-          CHART_VERSION: ${{ needs.get_version.outputs.app_version }}
-          APP_VERSION: ${{ needs.get_version.outputs.app_version }}
+          CHART_VERSION: $(jq -r '."."' .release-please-manifest.json)
+          APP_VERSION: $(jq -r '."."' .release-please-manifest.json)
           REGISTRY: ${{ steps.ecr_login.outputs.registry }}
           CHART: ${{ github.event.repository.name }}
         run: |
@@ -98,7 +76,6 @@ jobs:
     if: ${{ always() && !contains(needs.create_runner.result, 'failure') && !contains(needs.create_runner.result, 'skipped')}}
     needs:
       - create_runner
-      - get_version
       - publish_artifacts
     steps:
       - name: Destroy Runner

--- a/.github/workflows/release-please-prepare.yml
+++ b/.github/workflows/release-please-prepare.yml
@@ -35,8 +35,6 @@ jobs:
       - name: Release-Please
         id: release_please
         uses: google-github-actions/release-please-action@v4
-        with:
-          target-branch: PA-695-Release-Please
       - name: Get Release PR Number
         id: pr_number
         run: |

--- a/.github/workflows/release-please-prepare.yml
+++ b/.github/workflows/release-please-prepare.yml
@@ -1,0 +1,78 @@
+name: Release Please - Prepare
+on:
+  workflow_call:
+
+jobs:
+  create_runner:
+    name: Create Runner
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Create Runner
+        id: create_runner
+        uses: pagopa/pdnd-github-actions/deploy-eks-gh-runner@7fb09afd4227db40789da70cbdaa2c7157abff49
+        with:
+          name: ${{ github.event.repository.name }}
+          cluster_name: ${{ vars.RUNNER_CLUSTER_NAME }}
+          aws_runner_deploy_role: ${{ secrets.AWS_RUNNER_DEPLOY_ROLE }}
+          namespace: ${{ vars.RUNNER_K8S_NAMESPACE }}
+          image: ${{ vars.RUNNER_DOCKER_IMAGE }}
+          service_account: ${{ vars.RUNNER_SERVICE_ACCOUNT }}        
+          docker_enabled: true
+    outputs:
+      runner_label: ${{ steps.create_runner.outputs.runner_label }}
+  prepare_release:
+    name: Prepare Release
+    runs-on: [self-hosted, "${{ needs.create_runner.outputs.runner_label }}"]
+    needs:
+      - create_runner
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+      - name: Release-Please
+        id: release_please
+        uses: google-github-actions/release-please-action@v4
+        with:
+          target-branch: PA-695-Release-Please
+      - name: Get Release PR Number
+        id: pr_number
+        run: |
+          echo "RELEASE_PR_NUMBER=$(jq -r '.number' <<< ${{ toJSON(steps.release_please.outputs.pr) }})" >> "$GITHUB_OUTPUT"
+      - name: Approve Release PR
+        id: approve_pr
+        uses: hmarr/auto-approve-action@v3
+        with:
+          pull-request-number: ${{ steps.pr_number.outputs.RELEASE_PR_NUMBER }}
+          github-token: ${{ secrets.PAT_BOT }}
+      - name: Merge Release PR
+        id: merge_pr
+        uses: pascalgn/automerge-action@v0.16.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_BOT }}
+          PULL_REQUEST: ${{ steps.pr_number.outputs.RELEASE_PR_NUMBER }}
+          MERGE_LABELS: "autorelease: pending"
+          MERGE_METHOD: squash
+          MERGE_DELETE_BRANCH: true
+          MERGE_COMMIT_MESSAGE: "Automerge PR #${{ steps.pr_number.outputs.RELEASE_PR_NUMBER }}"
+  destroy_runner:
+    name: Destroy Runner
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    if: ${{ always() && !contains(needs.create_runner.result, 'failure') && !contains(needs.create_runner.result, 'skipped')}}
+    needs:
+      - create_runner
+      - prepare_release
+    steps:
+      - name: Destroy Runner
+        id: destroy_runner
+        uses: pagopa/pdnd-github-actions/undeploy-eks-gh-runner@7fb09afd4227db40789da70cbdaa2c7157abff49
+        with:
+          cluster_name: ${{ vars.RUNNER_CLUSTER_NAME }}
+          aws_runner_deploy_role: ${{ secrets.AWS_RUNNER_DEPLOY_ROLE }}
+          runner_label: ${{ needs.create_runner.outputs.runner_label }}
+          namespace:  ${{ vars.RUNNER_K8S_NAMESPACE }}


### PR DESCRIPTION
[PA-695](https://pagopa.atlassian.net/browse/PA-695)

1. **release-please-prepare.yml**: utilizza la _google-github-actions/release-please-action_ per gestire in automatico, mediante PR di rilascio ([Release PR](https://github.com/googleapis/release-please?tab=readme-ov-file#whats-a-release-pr)), le operazioni relative a tag, changelog, incremento di versione ecc. in base ai file di configurazione JSON sul progetto che chiama il _workflow_;
2. **release-please-microservice.yml**: aggiornamento del precedente **release-microservice.yml**, adesso calcola le versioni di immagine Docker e _chart_ Helm da rilasciare leggendo il manifest di _release-please_ sul progetto che chiama il _workflow_, indipendentemente dal linguaggio dell'applicativo;
3. **deploy-microservice.yml**: eliminato il parametro di input _application-version_, dato che le versioni di immagine Docker e _chart_ Helm coincidono sempre fra loro è sufficiente determinare la versione da installare a partire dal tag che ha innescato il _deploy_.

[PA-695]: https://pagopa.atlassian.net/browse/PA-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ