### PR TITLE
feat: autocommit latest digest to helm values

### DIFF
--- a/.github/workflows/release-please-microservice.yml
+++ b/.github/workflows/release-please-microservice.yml
@@ -58,6 +58,14 @@ jobs:
               -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -t $REGISTRY/$REPOSITORY:latest .
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:latest
+      - name: Update Helm Values
+        id: update_values
+        env:
+          REPOSITORY: ${{ github.event.repository.name }}
+          IMAGE_TAG: ${{ needs.get_version.outputs.app_version }}
+        run: |
+          LATEST_SHA=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids imageTag=$IMAGE_TAG | jq -r '.[] | .[].imageDigest') \
+          yq e '.image.digest = env(LATEST_SHA)' -i .k8s/helm/$REPOSITORY/values.yaml
       - name: Push Helm Chart to AWS ECR
         env:
           CHART_VERSION: $(jq -r '."."' .release-please-manifest.json)
@@ -67,6 +75,11 @@ jobs:
         run: |
           helm package .k8s/helm/$CHART --version $CHART_VERSION --app-version $APP_VERSION
           helm push $CHART-$CHART_VERSION.tgz oci://$REGISTRY/charts
+      - name: Commit Helm Values
+        id: commit_values
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Autocommit: update helm value image.digest to latest"
   destroy_runner:
     name: Destroy Runner
     runs-on: ubuntu-latest


### PR DESCRIPTION
[PA-722](https://pagopa.atlassian.net/browse/PA-722)

**release-please-microservice.yml**: dopo aver pubblicato l'immagine Docker e subito prima di procedere con il _chart_ Helm interroga AWS ECR ed estrae mediante JQ il _digest_ dell'ultima immagine rilasciata, dopodiché lo scrive sul **values.yaml** mediante YQ, infine esegue un _commit_ automatico del file appena aggiornato sul _repository_.

[PA-722]: https://pagopa.atlassian.net/browse/PA-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ