### PR TITLE
fix: determine tags and versions at runtime

### DIFF
--- a/.github/workflows/release-please-microservice.yml
+++ b/.github/workflows/release-please-microservice.yml
@@ -50,9 +50,9 @@ jobs:
         env:
           REGISTRY: ${{ steps.ecr_login.outputs.registry }}
           REPOSITORY: ${{ github.event.repository.name }}
-          IMAGE_TAG: $(jq -r '."."' .release-please-manifest.json)
           DOCKER_BUILDKIT: 1
         run: |
+          IMAGE_TAG=$(jq -r '."."' .release-please-manifest.json)
           docker build \
               --build-arg DOCKER_REGISTRY_URI=$REGISTRY \
               -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -t $REGISTRY/$REPOSITORY:latest .
@@ -62,17 +62,17 @@ jobs:
         id: update_values
         env:
           REPOSITORY: ${{ github.event.repository.name }}
-          IMAGE_TAG: ${{ needs.get_version.outputs.app_version }}
         run: |
+          IMAGE_TAG=$(jq -r '."."' .release-please-manifest.json)
           LATEST_SHA=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids imageTag=$IMAGE_TAG | jq -r '.[] | .[].imageDigest') \
           yq e '.image.digest = env(LATEST_SHA)' -i .k8s/helm/$REPOSITORY/values.yaml
       - name: Push Helm Chart to AWS ECR
         env:
-          CHART_VERSION: $(jq -r '."."' .release-please-manifest.json)
-          APP_VERSION: $(jq -r '."."' .release-please-manifest.json)
           REGISTRY: ${{ steps.ecr_login.outputs.registry }}
           CHART: ${{ github.event.repository.name }}
         run: |
+          CHART_VERSION=$(jq -r '."."' .release-please-manifest.json)
+          APP_VERSION=$(jq -r '."."' .release-please-manifest.json)
           helm package .k8s/helm --version $CHART_VERSION --app-version $APP_VERSION
           helm push $CHART-$CHART_VERSION.tgz oci://$REGISTRY/charts
       - name: Commit Helm Values


### PR DESCRIPTION
Fix aggiuntiva alla PR #38.

**.github/workflows/release-please-microservice.yml**: i parametri _IMAGE_TAG_, _CHART_VERSION_ e _APP_VERSION_ vengono calcolati da comandi Bash direttamente a _runtime_ anziché essere definiti fra le _env_.