### PR TITLE
fix: use same token for automerge and release-please

### DIFF
--- a/.github/workflows/release-please-prepare.yml
+++ b/.github/workflows/release-please-prepare.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Release-Please
         id: release_please
         uses: google-github-actions/release-please-action@v4
+        with:
+          token: ${{ secrets.PAT_BOT }}
       - name: Get Release PR Number
         id: pr_number
         run: |


### PR DESCRIPTION
Fix aggiuntiva alla PR https://github.com/pagopa/pdnd-github-actions/pull/40 .

.github/workflows/release-please-prepare.yml: l'azione di _release-please_ deve usare lo stesso _token_ dell'_automerge_ per evitare errori di autorizzazioni e integrazione.