### PR TITLE
fix: autocommit target branch

### DIFF
--- a/.github/workflows/release-please-microservice.yml
+++ b/.github/workflows/release-please-microservice.yml
@@ -79,6 +79,7 @@ jobs:
         id: commit_values
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
+          branch: ${{ github.base_ref }}
           commit_message: "Autocommit: update helm value image.digest to latest"
   destroy_runner:
     name: Destroy Runner

--- a/.github/workflows/release-please-prepare.yml
+++ b/.github/workflows/release-please-prepare.yml
@@ -35,8 +35,6 @@ jobs:
       - name: Release-Please
         id: release_please
         uses: google-github-actions/release-please-action@v4
-        with:
-          token: ${{ secrets.PAT_BOT }}
       - name: Get Release PR Number
         id: pr_number
         run: |


### PR DESCRIPTION
Fix aggiuntiva alla PR #40  .

- **.github/workflows/release-please-prepare.yml**: annullato il commit 61062cd e ripristinato il file precedente;

- **.github/workflows/release-please-microservice.yml**: l'_autocommit_ dei _values_ aggiornati punta al _branch_ destinazione della PR che ha innescato il rilascio.