### PR TITLE
fix: autocommit only helm values

### DIFF
--- a/.github/workflows/release-please-microservice.yml
+++ b/.github/workflows/release-please-microservice.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           branch: ${{ github.base_ref }}
           commit_message: "Autocommit: update helm value image.digest to latest"
+          file_pattern: '.k8s/helm/values.yaml'
   destroy_runner:
     name: Destroy Runner
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix aggiuntiva alla PR #40  .

- **.github/workflows/release-please-microservice.yml**: l'azione di _autocommit_ esegue il _push_ esclusivamente del **values.yaml** ignorando tutto il resto.