### PR TITLE
fix: update actions version

### DIFF
--- a/.github/workflows/build-analyze-quarkus-ms.yml
+++ b/.github/workflows/build-analyze-quarkus-ms.yml
@@ -36,18 +36,18 @@ jobs:
     runs-on: [self-hosted, "${{ needs.create_runner.outputs.runner_label }}"]
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           ref: ${{ inputs.ref_name }}
           persist-credentials: false
       - name: Cache SonarCloud packages
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2

--- a/.github/workflows/deploy-microservice.yml
+++ b/.github/workflows/deploy-microservice.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Verify tag
         id: tag_verify
-        uses: nowsprinting/check-version-format-action@v3
+        uses: nowsprinting/check-version-format-action@de7dcbd404b253dd775262e49c9924fa834e17a2 # v4.0.3
         with:
           prefix: 'v'
       - name: Get Target Namespace
@@ -88,7 +88,7 @@ jobs:
           python3 /tmp/openapi_integration.py -i ${{ inputs.openapi-folder }}/openapi.yaml -o ${{ vars.AWS_OPENAPI_PATH }}
       - name: Setup Git Credentials
         id: openapi_git_credentials
-        uses: de-vri-es/setup-git-credentials@162b9dfe472513ee2960f0c97dd3cbbe80319b68 # v2.0.10
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2.1.2
         with:
           credentials: https://pdnd-pagopa-github-bot:${{ secrets.PAT_BOT }}@github.com/
       - name : Deploy OpenAPI

--- a/.github/workflows/deploy-quarkus-ms.yml
+++ b/.github/workflows/deploy-quarkus-ms.yml
@@ -37,18 +37,18 @@ jobs:
       - create_runner
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           ref: ${{ inputs.ref_name }}
           persist-credentials: false
       - name: Cache Maven packages
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2
           restore-keys: ${{ runner.os }}-m2
       - name : Setup python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: '3.9'
           cache: 'pip'
@@ -66,7 +66,7 @@ jobs:
           VERSION="${{ github.ref_name }}"
           echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
       - name: setup-git-credentials
-        uses: de-vri-es/setup-git-credentials@162b9dfe472513ee2960f0c97dd3cbbe80319b68 # v2.0.10
+        uses: de-vri-es/setup-git-credentials@5e1f18da68b7039c7f824408d170811aaec93ca8 # v2.1.2
         with:
           credentials: https://pdnd-pagopa-github-bot:${{ secrets.PAT_BOT }}@github.com/
       - name: Login to Amazon ECR

--- a/.github/workflows/release-airflow-pipeline.yml
+++ b/.github/workflows/release-airflow-pipeline.yml
@@ -47,7 +47,7 @@ jobs:
       runs-on: [self-hosted, "${{ needs.create_runner.outputs.runner_label }}"]
       needs: create_runner
       steps:
-        - uses: nowsprinting/check-version-format-action@447b28744b1b954470f128d1d86ff636164c87c1
+        - uses: nowsprinting/check-version-format-action@de7dcbd404b253dd775262e49c9924fa834e17a2 # v4.0.3
           id: version
           with:
             prefix: 'v'
@@ -57,7 +57,7 @@ jobs:
                 echo "Version: ${{github.ref_name}} is not valid!"
                 exit 1
         - name: Check out the repo
-          uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         - name: Create AWS ECR repository
           uses: pagopa/pdnd-github-actions/create-ecr-repository@74cf3f8abfacd6814b924408a11b02f177f8f5a3
           with:

--- a/.github/workflows/release-microservice.yml
+++ b/.github/workflows/release-microservice.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ github.base_ref }}
       - name: Release-Please
         id: release_please
-        uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:
           skip-github-release: false
           skip-github-pull-request: false
@@ -155,7 +155,7 @@ jobs:
           ref: ${{ github.base_ref }}
       - name: Approve Release PR
         id: approve_pr
-        uses: hmarr/auto-approve-action@v3
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4
         with:
           pull-request-number: ${{ needs.prepare-release.outputs.release_pr_number }}
           github-token: ${{ secrets.PAT_BOT }}
@@ -171,7 +171,7 @@ jobs:
           MERGE_COMMIT_MESSAGE: "Automerge PR #${{ needs.prepare-release.outputs.release_pr_number }}"
       - name: Release-Please
         id: release_please
-        uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:
           skip-github-release: false
           skip-github-pull-request: false

--- a/.github/workflows/release-node-ui-dataviz.yml
+++ b/.github/workflows/release-node-ui-dataviz.yml
@@ -36,7 +36,7 @@ jobs:
             contents: read
       needs: create_runner
       steps:
-        - uses: nowsprinting/check-version-format-action@447b28744b1b954470f128d1d86ff636164c87c1
+        - uses: nowsprinting/check-version-format-action@de7dcbd404b253dd775262e49c9924fa834e17a2 # v4.0.31
           id: version
           with:
             prefix: 'v'
@@ -46,7 +46,7 @@ jobs:
                 echo "Version: ${{github.ref_name}} is not valid!"
                 exit 1
         - name: Check out the repo
-          uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         - name: Set S3 url from input
           if: inputs.s3_url != ''
           run: |

--- a/.github/workflows/release-python-module.yml
+++ b/.github/workflows/release-python-module.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: libs/${{ inputs.working-directory }}
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/release-python-pkg.yml
+++ b/.github/workflows/release-python-pkg.yml
@@ -29,7 +29,7 @@ jobs:
       runs-on: [self-hosted, "${{ needs.create_runner.outputs.runner_label }}"]
       needs: create_runner
       steps:
-        - uses: nowsprinting/check-version-format-action@447b28744b1b954470f128d1d86ff636164c87c1
+        - uses: nowsprinting/check-version-format-action@de7dcbd404b253dd775262e49c9924fa834e17a2 # v4.0.3
           id: version
           with:
             prefix: 'v'
@@ -39,7 +39,7 @@ jobs:
                 echo "Version: ${{github.ref_name}} is not valid!"
                 exit 1
         - name: Check out the repo
-          uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         - name: Login to code artifact
           run: |
             echo CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ vars.CODE_ARTIFACT_DOMAIN }} --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} \

--- a/.github/workflows/release-quarkus-ms.yml
+++ b/.github/workflows/release-quarkus-ms.yml
@@ -44,7 +44,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           token: ${{ secrets.PAT_BOT }}
       - name: Check default branch
@@ -58,12 +58,12 @@ jobs:
         with:
           node-version: 18
       - name : Setup python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: '3.9'
           cache: 'pip'
       - name: Cache Maven packages
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2

--- a/ovpn-connect/action.yml
+++ b/ovpn-connect/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
     - name: Install OpenVPN
       run: |
         sudo apt update


### PR DESCRIPTION
1. [ ] update actions/checkout from v3 to v4
2. [ ] update actions/cache from v3 to v4.0.2
3. [ ] update actions/setup-python from v4 to v5.1.1
4. [ ] update hmarr/auto-approve-action from v3 to v4
5. [ ] update nowsprinting/check-version-format-action from v3 to v4.0.3 
6. [ ] update de-vri-es/setup-git-credentials from v2.0.10 to v2.1.2
7. [ ] migrate google-github-actions/release-please-action to  googleapis/release-please-action v4.1.3 